### PR TITLE
Implement DocumentsProvider to allow users to edit files in app's internal directory

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+        
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|screenSize"
@@ -50,6 +51,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        
+        <provider
+            android:authorities="net.rpcs3.documents"
+            android:name="net.rpcs3.provider.AppDataDocumentProvider"
+            android:exported="true"
+            android:grantUriPermissions="true"
+            android:permission="android.permission.MANAGE_DOCUMENTS">
+            <intent-filter>
+                <action android:name="android.content.action.DOCUMENTS_PROVIDER" />
+            </intent-filter>
+        </provider>
+        
     </application>
-
 </manifest>

--- a/app/src/main/java/net/rpcs3/provider/AppDataDocumentProvider.kt
+++ b/app/src/main/java/net/rpcs3/provider/AppDataDocumentProvider.kt
@@ -49,7 +49,7 @@ class AppDataDocumentProvider : DocumentsProvider() {
 
     private fun context(): Context = context!!
 
-    private fun baseDirectory(): File = context().getExternalFilesDir(null)
+    private fun baseDirectory(): File = context().getExternalFilesDir(null)!!
 
     override fun onCreate(): Boolean = true
 

--- a/app/src/main/java/net/rpcs3/provider/AppDataDocumentProvider.kt
+++ b/app/src/main/java/net/rpcs3/provider/AppDataDocumentProvider.kt
@@ -1,0 +1,124 @@
+package net.rpcs3.provider
+
+import android.content.Context
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.os.CancellationSignal
+import android.os.ParcelFileDescriptor
+import android.provider.DocumentsContract.Document
+import android.provider.DocumentsContract.Root
+import android.provider.DocumentsProvider
+import net.rpcs3.R
+import java.io.File
+import java.io.FileNotFoundException
+
+class AppDataDocumentProvider : DocumentsProvider() {
+    companion object {
+        private const val ROOT_ID = "root"
+
+        private val DEFAULT_ROOT_PROJECTION = arrayOf(
+            Root.COLUMN_ROOT_ID,
+            Root.COLUMN_MIME_TYPES,
+            Root.COLUMN_FLAGS,
+            Root.COLUMN_ICON,
+            Root.COLUMN_TITLE,
+            Root.COLUMN_SUMMARY,
+            Root.COLUMN_DOCUMENT_ID,
+            Root.COLUMN_AVAILABLE_BYTES
+        )
+
+        private val DEFAULT_DOCUMENT_PROJECTION = arrayOf(
+            Document.COLUMN_DOCUMENT_ID,
+            Document.COLUMN_DISPLAY_NAME,
+            Document.COLUMN_MIME_TYPE,
+            Document.COLUMN_LAST_MODIFIED,
+            Document.COLUMN_SIZE
+        )
+    }
+
+    private fun obtainDocumentId(file: File): String {
+        val basePath = baseDirectory().absolutePath
+        val fullPath = file.absolutePath
+        return (ROOT_ID + "/" + fullPath.substring(basePath.length)).replace("//", "/")
+    }
+
+    private fun obtainFile(documentId: String): File {
+        require(documentId.startsWith(ROOT_ID)) { "Invalid document id: $documentId" }
+        return File(baseDirectory(), documentId.substring(ROOT_ID.length))
+    }
+
+    private fun context(): Context = context!!
+
+    private fun baseDirectory(): File = context().getExternalFilesDir(null)
+
+    override fun onCreate(): Boolean = true
+
+    override fun queryRoots(projection: Array<out String>?): Cursor {
+        val cursor = MatrixCursor(projection ?: DEFAULT_ROOT_PROJECTION)
+        cursor.newRow()
+            .add(Root.COLUMN_ROOT_ID, ROOT_ID)
+            .add(Root.COLUMN_SUMMARY, null)
+            .add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_IS_CHILD or Root.FLAG_SUPPORTS_CREATE)
+            .add(Root.COLUMN_DOCUMENT_ID, "$ROOT_ID/")
+            .add(Root.COLUMN_AVAILABLE_BYTES, baseDirectory().freeSpace)
+            .add(Root.COLUMN_TITLE, context().getString(R.string.app_name))
+            .add(Root.COLUMN_MIME_TYPES, "*/*")
+            .add(Root.COLUMN_ICON, R.mipmap.ic_launcher)
+        return cursor
+    }
+
+    override fun queryDocument(documentId: String, projection: Array<out String>?): Cursor {
+        val cursor = MatrixCursor(projection ?: DEFAULT_DOCUMENT_PROJECTION)
+        includeFile(cursor, obtainFile(documentId))
+        return cursor
+    }
+
+    private fun includeFile(cursor: MatrixCursor, file: File) {
+        val flags = when {
+            file.isDirectory -> Document.FLAG_DIR_SUPPORTS_CREATE or Document.FLAG_SUPPORTS_DELETE
+            else -> Document.FLAG_SUPPORTS_WRITE or Document.FLAG_SUPPORTS_REMOVE or Document.FLAG_SUPPORTS_DELETE
+        }
+
+        cursor.newRow()
+            .add(Document.COLUMN_DOCUMENT_ID, obtainDocumentId(file))
+            .add(Document.COLUMN_MIME_TYPE, if (file.isDirectory) Document.MIME_TYPE_DIR else "application/octet-stream")
+            .add(Document.COLUMN_FLAGS, flags)
+            .add(Document.COLUMN_LAST_MODIFIED, file.lastModified())
+            .add(Document.COLUMN_DISPLAY_NAME, file.name)
+            .add(Document.COLUMN_SIZE, file.length())
+    }
+
+    override fun queryChildDocuments(parentDocumentId: String, projection: Array<out String>?, sortOrder: String?): Cursor {
+        val cursor = MatrixCursor(projection ?: DEFAULT_DOCUMENT_PROJECTION)
+        obtainFile(parentDocumentId).listFiles()?.forEach { includeFile(cursor, it) }
+        return cursor
+    }
+
+    override fun createDocument(parentDocumentId: String, mimeType: String, displayName: String): String {
+        val parent = obtainFile(parentDocumentId)
+        val file = File(parent, displayName)
+
+        if (!parent.exists()) throw FileNotFoundException("Parent doesn't exist")
+
+        if (mimeType == Document.MIME_TYPE_DIR) {
+            if (!file.mkdirs()) throw FileNotFoundException("Error while creating directory")
+        } else {
+            if (!file.createNewFile()) throw FileNotFoundException("Error while creating file")
+        }
+
+        return obtainDocumentId(file)
+    }
+
+    override fun deleteDocument(documentId: String) {
+        val file = obtainFile(documentId)
+        if (file.exists()) {
+            file.deleteRecursively()
+        } else {
+            throw FileNotFoundException("File not exists")
+        }
+    }
+
+    override fun openDocument(documentId: String, mode: String, signal: CancellationSignal?): ParcelFileDescriptor {
+        return ParcelFileDescriptor.open(obtainFile(documentId), ParcelFileDescriptor.parseMode(mode))
+    }
+}


### PR DESCRIPTION
### How to Use
Open the Files app on your Android device. Since it's a system app, you can't open it directly through third-party apps, which is why a UI is needed to access Internal Storage.
For now, you can use any Shortcut App to launch Android's default Files app.
Keep RPCS3 running in the background while doing this.
Once the Files app is open, look for the three-dot menu in the top-left corner and tap on it.
In the menu that appears, you should see RPCS3 listed. Tap on it.
You have now successfully accessed the internal storage of the RPCS3 app.