### PR TITLE
AppDataDocumentProvider: Add missing ``COLUMN_FLAGS`` in the default …

### DIFF
--- a/app/src/main/java/net/rpcs3/provider/AppDataDocumentProvider.kt
+++ b/app/src/main/java/net/rpcs3/provider/AppDataDocumentProvider.kt
@@ -32,6 +32,7 @@ class AppDataDocumentProvider : DocumentsProvider() {
             Document.COLUMN_DISPLAY_NAME,
             Document.COLUMN_MIME_TYPE,
             Document.COLUMN_LAST_MODIFIED,
+            Document.COLUMN_FLAGS,
             Document.COLUMN_SIZE
         )
     }


### PR DESCRIPTION
…document projectation

Fixes unable to copy files from device to app's internal storage problem