### PR TITLE
provider: Remove hard-coded string 'AUTHORITY'

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,7 +61,7 @@
         </activity>
         
         <provider
-            android:authorities="net.rpcs3.documents"
+            android:authorities="${applicationId}.documents"
             android:name="net.rpcs3.provider.AppDataDocumentProvider"
             android:exported="true"
             android:grantUriPermissions="true"

--- a/app/src/main/java/net/rpcs3/provider/AppDataDocumentProvider.kt
+++ b/app/src/main/java/net/rpcs3/provider/AppDataDocumentProvider.kt
@@ -16,7 +16,6 @@ import java.io.IOException
 class AppDataDocumentProvider : DocumentsProvider() {
     companion object {
         const val ROOT_ID = "root"
-        const val AUTHORITY = "net.rpcs3" + ".documents"
 
         private val DEFAULT_ROOT_PROJECTION = arrayOf(
             Root.COLUMN_ROOT_ID,

--- a/app/src/main/java/net/rpcs3/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/net/rpcs3/ui/settings/SettingsScreen.kt
@@ -393,7 +393,7 @@ fun SettingsScreen(
                     val file = DocumentFile.fromSingleUri(
                         context,
                         DocumentsContract.buildDocumentUri(
-                            AppDataDocumentProvider.AUTHORITY,
+                            "${context.packageName}.documents",
                             "${AppDataDocumentProvider.ROOT_ID}/cache/RPCS3.log"
                         )
                     )
@@ -429,7 +429,7 @@ private fun Context.launchBrowseIntent(
         val intent = Intent(action).apply {
             addCategory(Intent.CATEGORY_DEFAULT)
             data = DocumentsContract.buildRootUri(
-                AppDataDocumentProvider.AUTHORITY,
+                "$packageName.documents",
                 AppDataDocumentProvider.ROOT_ID
             )
             addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_PREFIX_URI_PERMISSION or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)


### PR DESCRIPTION
- We should use a method of dynamically obtaining application ID instead of using hard-coded package name, which is not conducive to building different variants.